### PR TITLE
Let node exit with code 1 when there is an error

### DIFF
--- a/src/bgcl.js
+++ b/src/bgcl.js
@@ -2339,6 +2339,7 @@ BGCL.prototype.run = function() {
     console.error(err.message || err);
     // console.error();
     // console.error(err.stack);
+    process.exit(1);
   })
   .done();
 };


### PR DESCRIPTION
It would be nice if node exited with anything else than 0 when it runs into an uncaught error.
Without this we would have to parse every output of every command and re-implement error handling  in the script calling the bitgo-cli. This way we can check if $? succeed and if it didn't we just output the error message. A next step would be to add meaningful error codes if we'd still want to handle specific errors differently.