### PR TITLE
update passwords and schema for splited keys

### DIFF
--- a/src/bgcl.js
+++ b/src/bgcl.js
@@ -2608,7 +2608,7 @@ BGCL.prototype.handleUpdateKey = function() {
     var xpub = extendedKey.neutered().toBase58();
     //var xprv = self.args.verifyonly ? undefined : extendedKey.toBase58();
     if (xpub !== key.xpub) {
-      throw new Error("xpubs don't match for key " + key.index);
+      throw new Error("xpubs don't match for key " + index);
     }
   })
   .then(input.getIntVariable('n', 'Number of shares per key (N) (new eschema): ', true, 1, 10))
@@ -2620,9 +2620,12 @@ BGCL.prototype.handleUpdateKey = function() {
     return input.getIntVariable('m', 'Number of shares required to restore key (M <= N) (new eschema): ', true, mMin, input.n)();
   })
   .then(function(){
+    console.log("Generating " + input.n + " new shared secrets for key #" + index + ". set the passwords:");
     return getEncryptPassword(0, input.n);
   })
   .then(function(){
+    // re generate key with new schema and passwords and.
+    // update keys and wirte them back to original json file.
     var extendedKey = bitcoin.HDNode.fromSeedHex(seed);
     input['key'] = {
       seed: seed,
@@ -2630,6 +2633,7 @@ BGCL.prototype.handleUpdateKey = function() {
       xprv: extendedKey.toBase58()
     }
     var cryptedKey = self.genSplitKey(input);
+    cryptedKey['index'] = index;
     keys[index] = cryptedKey;
     fs.writeFileSync(input.file, JSON.stringify(keys, null, 2));
     console.log('Wrote ' + input.file);


### PR DESCRIPTION
This is an addition i did to bitgo-cli to allow change passwords and schema (m of n) of previosuly created splited keys. This is important to be able to handle grant/revoke access to any user created key.
It only change 1 key at a time to avoid mistakes. reads it form a json generated split key file, then uses genSplitKey which i modified to accept an argument 'key' in params and make the split with that key, if no 'key' param is specified a new key is generated.

bitgo help updatekey
usage: bitgo updatekey [-h] [-m M] [-n N] [-f FILE] [-k KEY]

Optional arguments:
  -h, --help            Show this help message and exit.
  -m M                  number of shares required to reconstruct a key
  -n N                  total number of shares per key
  -f FILE, --file FILE  the input file (JSON format)
  -k KEY, --key KEY     key index to update

