### PR TITLE
superagent v1 requires superagent-proxy v1

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "secrets.js": "0.1.8",
     "sjcl": "1.0.1",
     "superagent": "1.2.0",
+    "superagent-proxy": "1.0.0",
     "superagent-as-promised": "3.1.1",
     "underscore.string": "2.4.0"
   },


### PR DESCRIPTION
superagent v1 seems to be requiring superagent-proxy v1, and therefore this change was required for npm install to bundle successfully
