### PR TITLE
add essential parameters to sendtoaddress command

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/BitGo/bitgo-cli",
   "dependencies": {
     "argparse": "1.0.2",
-    "bitgo": "2.2.0",
+    "bitgo": "3.2.8",
     "bs58check": "1.0.5",
     "lodash": "2.4.1",
     "moment": "2.9.0",

--- a/src/bgcl.js
+++ b/src/bgcl.js
@@ -1869,11 +1869,11 @@ BGCL.prototype.handleSendToAddress = function() {
   })
   .then(function(txResult) {
     var amounts = [];
-    amounts.push(util.format('BTC %s', self.toBTC(txParams.recipients[0].amount)));
+    amounts.push(util.format('BTC %s', self.toBTC(txParams.recipients[0].amount, 8)));
     if (txResult.bitgoFee) {
-      amounts.push(util.format('%s BitGo fee', self.toBTC(txResult.bitgoFee.amount)));
+      amounts.push(util.format('%s BitGo fee', self.toBTC(txResult.bitgoFee.amount, 8)));
     }
-    amounts.push(util.format('%s blockchain fee', self.toBTC(txResult.fee)));
+    amounts.push(util.format('%s blockchain fee', self.toBTC(txResult.fee, 8)));
     var prefix = input.confirm ? 'Sending' : 'Please confirm sending';
     self.info(prefix + ' ' + amounts.join(' + ') +  ' to ' + txParams.recipients[0].address + '\n');
     return input.getVariable('confirm', 'Type \'go\' to confirm: ')();


### PR DESCRIPTION
Helps fine-tuning against transaction malleability and also allows to change the default fee which is important with the recent fully crowded blocks during busy hours.

My aim was to not change default values to make sure we won't be breaking existing implementation.
