### PR TITLE
Support sending to multiple recepients

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ subcommands:
     consolidate         Consolidate unspents in a wallet
     fanout              Fan out unspents in a wallet
     sendtoaddress       Create and send a transaction
+    sendtomany          Create and send a transaction to multiple recepients
     newkey              Create a new BIP32 keychain (client-side only)
     splitkeys           Create set of BIP32 keys, split into encrypted shares.
     verifysplitkeys     Verify the public keys contained in the output file
@@ -339,7 +340,28 @@ Destination address: 2N6d5SYvu1xQeSQnpZ4VNVZ6TcRYcqkocao
 Amount (in BTC): 0.5
 Wallet passcode: ********************
 Optional comment: paying Mike for lunch
-Please confirm sending BTC 0.5000 + 0.0001 blockchain fee to 2N6d5SYvu1xQeSQnpZ4VNVZ6TcRYcqkocao
+Please confirm sending BTC 0.5000 + 0.0001 blockchain fee:
+  0.5000 to 2N6d5SYvu1xQeSQnpZ4VNVZ6TcRYcqkocao
+Type 'go' to confirm: go
+2-step Verification Code: 0000000
+*** Unlocked session
+*** Sent transaction 9ef2042647ceb0b1ec8f18733ab46d11c330b4449549fe37a9c559e170806d0e
+```
+
+## sendtomany
+Send a transaction to multiple recepients at once. Similarly to `sendtoaddress`, this command provides a guided flow, but the needed info may also be provided on the command line.
+```
+$ bitgo -e test sendtomany
+Current wallet: 2N9VaC4SDRNNnEy6G8zLF8gnHgkY6LV9PsX
+Send Transaction:
+
+JSON dictionary of recipients in address: amountInBTC format, e.g. { "LgAQ524UwZz2Nq59CUb4m5CGVWYSZH83B1": 5, "LUMZucN2rvbVryAYP5Ba43d9NcMedaRNn1": 2 }: { "mjp5HeoDJQHo7yfZSPfcNpSkoBRdPzRjWs": 0.5, "mo4mbU89mkFD8JLZ1aVwRUVbfvYcppwzqe": 0.2, "mfXrwmbR82ht39n7o8ga1AAeVzd9aZTv16": 0.3 }
+Wallet passcode: ********************
+Optional comment: paying Mike for lunch, Tim for beers
+Please confirm sending BTC 1.0000 + 0.0001 blockchain fee:
+  0.5000 to mjp5HeoDJQHo7yfZSPfcNpSkoBRdPzRjWs
+  0.2000 to mo4mbU89mkFD8JLZ1aVwRUVbfvYcppwzqe
+  0.3000 to mfXrwmbR82ht39n7o8ga1AAeVzd9aZTv16
 Type 'go' to confirm: go
 2-step Verification Code: 0000000
 *** Unlocked session

--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ $ bitgo fanout -t 20        # fan out all the unspents into a total of 20 unspen
 ## sendtoaddress
 Send a transaction. This command provides a guided flow, but the needed info may also be provided on the command line.
 ```
-$ bitgo -e test send
+$ bitgo -e test sendtoaddress
 Current wallet: 2N9VaC4SDRNNnEy6G8zLF8gnHgkY6LV9PsX
 Send Transaction:
 

--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ $ bitgo -e test sendtomany
 Current wallet: 2N9VaC4SDRNNnEy6G8zLF8gnHgkY6LV9PsX
 Send Transaction:
 
-JSON dictionary of recipients in address: amountInBTC format, e.g. { "LgAQ524UwZz2Nq59CUb4m5CGVWYSZH83B1": 5, "LUMZucN2rvbVryAYP5Ba43d9NcMedaRNn1": 2 }: { "mjp5HeoDJQHo7yfZSPfcNpSkoBRdPzRjWs": 0.5, "mo4mbU89mkFD8JLZ1aVwRUVbfvYcppwzqe": 0.2, "mfXrwmbR82ht39n7o8ga1AAeVzd9aZTv16": 0.3 }
+JSON dictionary of recipients in address: amountInBTC format, e.g. [{"address": "LgAQ524UwZz2Nq59CUb4m5CGVWYSZH83B1", "amount": 5}, {"address": "LUMZucN2rvbVryAYP5Ba43d9NcMedaRNn1", "amount": 2}, {"address": "mjp5HeoDJQHo7yfZSPfcNpSkoBRdPzRjWs", "amount": 0.5}, {"address": "mo4mbU89mkFD8JLZ1aVwRUVbfvYcppwzqe", "amount": 0.2}, {"address": "mfXrwmbR82ht39n7o8ga1AAeVzd9aZTv16", "amount": 0.3}]
 Wallet passcode: ********************
 Optional comment: paying Mike for lunch, Tim for beers
 Please confirm sending BTC 1.0000 + 0.0001 blockchain fee:

--- a/src/bgcl.js
+++ b/src/bgcl.js
@@ -472,6 +472,13 @@ BGCL.prototype.createArgumentParser = function() {
   sendToAddress.addArgument(['-c', '--comment'], {help: 'optional private comment'});
   sendToAddress.addArgument(['-u', '--unconfirmed'], { nargs: 0, help: 'allow spending unconfirmed external inputs'});
   sendToAddress.addArgument(['--confirm'], {action: 'storeConst', constant: 'go', help: 'skip interactive confirm step -- be careful!'});
+  sendToAddress.addArgument(['--fee'], {type: 'int', nargs: '?', help: 'optional - custom fee to use with this transaction in satoshis.  if not provided, a default, minimum fee will be used'});
+  sendToAddress.addArgument(['--feeRate'], {type: 'int', nargs: '?', help: 'optional - the amount of fee in satoshis per kilobyte - specify either fee, feeRate, or feeTxConfirmTarget but not more than one'});
+  sendToAddress.addArgument(['--feeTxConfirmTarget'], {type: 'int', nargs: '?', help: 'optional - calculate fees dynamically so that the transaction will be confirmed in this number of blocks'});
+  sendToAddress.addArgument(['--maxFeeRate'], {type: 'int', nargs: '?', help: 'optional - The maximum fee per kb to use in satoshis, for safety purposes when using dynamic fees, for example when specifying the --feeTxConfirmTarget option'});
+  sendToAddress.addArgument(['--minConfirms'], {type: 'int', nargs: '?', help: 'optional - the minimum confirmations an output must have before spending. Overrides --unconfirmed option if present'});
+  sendToAddress.addArgument(['--enforceMinConfirmsForChange'], {action: 'storeTrue', help: 'apply minConfirms setting for change addresses too'});
+  sendToAddress.addArgument(['--targetWalletUnspents'], {type: 'int', nargs: '?', help: 'optional - The number of UTXO\'s that will exist after a transaction is sent'});
 
   // sendtomany
   var sendToMany = subparsers.addParser('sendtomany', {
@@ -484,6 +491,13 @@ BGCL.prototype.createArgumentParser = function() {
   sendToMany.addArgument(['-c', '--comment'], {help: 'optional private comment'});
   sendToMany.addArgument(['-u', '--unconfirmed'], { nargs: 0, help: 'allow spending unconfirmed external inputs'});
   sendToMany.addArgument(['--confirm'], {action: 'storeConst', constant: 'go', help: 'skip interactive confirm step -- be careful!'});
+  sendToMany.addArgument(['--fee'], {type: 'int', nargs: '?', help: 'optional - custom fee to use with this transaction in satoshis.  if not provided, a default, minimum fee will be used'});
+  sendToMany.addArgument(['--feeRate'], {type: 'int', nargs: '?', help: 'optional - the amount of fee in satoshis per kilobyte - specify either fee, feeRate, or feeTxConfirmTarget but not more than one'});
+  sendToMany.addArgument(['--feeTxConfirmTarget'], {type: 'int', nargs: '?', help: 'optional - calculate fees dynamically so that the transaction will be confirmed in this number of blocks'});
+  sendToMany.addArgument(['--maxFeeRate'], {type: 'int', nargs: '?', help: 'optional - The maximum fee per kb to use in satoshis, for safety purposes when using dynamic fees, for example when specifying the --feeTxConfirmTarget option'});
+  sendToMany.addArgument(['--minConfirms'], {type: 'int', nargs: '?', help: 'optional - the minimum confirmations an output must have before spending. Overrides --unconfirmed option if present'});
+  sendToMany.addArgument(['--enforceMinConfirmsForChange'], {action: 'storeTrue', help: 'apply minConfirms setting for change addresses too'});
+  sendToMany.addArgument(['--targetWalletUnspents'], {type: 'int', nargs: '?', help: 'optional - The number of UTXO\'s that will exist after a transaction is sent'});
 
   // freezewallet
   var freezeWallet = subparsers.addParser('freezewallet', {
@@ -1902,9 +1916,15 @@ BGCL.prototype.handleSendTo = function() {
       walletPassphrase: input.password,
       message: input.comment,
       minConfirms: input.unconfirmed ? 0 : 1,
-      enforceMinConfirmsForChange: true,
+      enforceMinConfirmsForChange: input.enforceMinConfirmsForChange,
       changeAddress: wallet.id()
     };
+
+    var optionalParamKeys = ['fee', 'feeRate', 'feeTxConfirmTarget', 'maxFeeRate', 'minConfirms', 'targetWalletUnspents'];
+    var optionalParams = _.pick(input, function(value, key) {
+      return _.contains(optionalParamKeys, key) && !_.isNull(value);
+    });
+    txParams = _.extend(txParams, optionalParams);
 
     return wallet.createTransaction(txParams)
     .catch(function(err) {

--- a/src/bgcl.js
+++ b/src/bgcl.js
@@ -485,7 +485,7 @@ BGCL.prototype.createArgumentParser = function() {
     addHelp: true,
     help: 'Create and send a transaction to multiple addresses'
   });
-  sendToMany.addArgument(['-r', '--recipients'], {help: 'JSON dictionary of recipients in address: amountInBTC format, e.g. { "LgAQ524UwZz2Nq59CUb4m5CGVWYSZH83B1": 5, "LUMZucN2rvbVryAYP5Ba43d9NcMedaRNn1": 2 }'});
+  sendToMany.addArgument(['-r', '--recipients'], {help: 'JSON array of recipient objects with attributes: address, amount, e.g. {[{"address": "LgAQ524UwZz2Nq59CUb4m5CGVWYSZH83B1", "amount": 5}, {"address": "LUMZucN2rvbVryAYP5Ba43d9NcMedaRNn1", "amount": 2}]'});
   sendToMany.addArgument(['-p', '--password'], {help: 'the wallet password'});
   sendToMany.addArgument(['-o', '--otp'], {help: 'the 2-step verification code'});
   sendToMany.addArgument(['-c', '--comment'], {help: 'optional private comment'});
@@ -1862,7 +1862,7 @@ BGCL.prototype.handleSendTo = function() {
         .then(input.getVariable('amount', 'Amount (in BTC): '));
       case 'sendtomany':
         return Q()
-        .then(input.getVariable('recipients', 'JSON dictionary of recipients in address: amountInBTC format, e.g. { "LgAQ524UwZz2Nq59CUb4m5CGVWYSZH83B1": 5, "LUMZucN2rvbVryAYP5Ba43d9NcMedaRNn1": 2 }: '));
+        .then(input.getVariable('recipients', 'JSON array of recipient objects with attributes: address, amount, e.g. {[{"address": "LgAQ524UwZz2Nq59CUb4m5CGVWYSZH83B1", "amount": 5}, {"address": "LUMZucN2rvbVryAYP5Ba43d9NcMedaRNn1", "amount": 2}]: '));
     }
   })
   .then(input.getVariable('password', 'Wallet password: '))
@@ -1881,13 +1881,7 @@ BGCL.prototype.handleSendTo = function() {
 
       case 'sendtomany':
         try {
-          var recepientsInput = JSON.parse(input.recipients);
-          Object.keys(recepientsInput).forEach((address)=> {
-            recipients.push({
-              address: address,
-              amount: recepientsInput[address]
-            });
-          });
+          recipients = JSON.parse(input.recipients);
         } catch (e) {
           throw new Error('Error parsing recepients param. Wrong JSON format?');
         }


### PR DESCRIPTION
This PR adds a new `sendtomany` command that accepts a `--recepients` or `-r` parameter with a JSON array that contains objects with attributes of address and amount. ~~This format follows the semantics that already exists in the codebase (`recoverlitecoin` helper tool).~~ __Update:__ _this is no longer the case. The problem was that before 4bf5d45 an address can only be used once in a single command._

Along with the above additions, these enhancements are also part of the PR:
- Display more precise amount (8 decimal places) and fees when confirming a tx using `sendtoaddress` and `sendtomany` to be able to distinguish when overriding fee calculation
- Accept optional arguments for `sendtoaddress` and `sendtomany` that are, when provided, passed directly to the BitGo lib. The options are: `fee`, `feeRate`, `feeTxConfirmTarget`, `maxFeeRate`, `minConfirms`, `enforceMinConfirmsForChange`, `targetWalletUnspents`.
- Minor fix in README